### PR TITLE
Add debug symbols to the device app ELF files

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -8,7 +8,7 @@ INCLUDE=include
 # debug port, remove -DNODEBUG below
 CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany \
    -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf \
-   -fno-builtin-putchar -nostdlib -mno-relax -flto \
+   -fno-builtin-putchar -nostdlib -mno-relax -flto -g \
    -Wall -Werror=implicit-function-declaration \
    -I $(INCLUDE) -I . \
    -DNODEBUG


### PR DESCRIPTION
Does not effect the .bin files.

Also see https://github.com/tillitis/dev-tillitis/pull/6 for an example of how to use with GDB.