### PR TITLE
Include information about embedded device app in version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,20 @@ For convenience, and to be able to support `go install` a precompiled
 [signer device app](https://github.com/tkey-device-signer) binary is
 included under `cmd/tkey-ssh-agent`.
 
-If you want to replace the signer used you have to:
+If you want to replace the signer used by the agent you have to:
 
-1. Compile your own signer and place it in `cmd/tkey-ssh-agent`.
-2. Change the path to the embedded signer in `cmd/tkey-ssh-agent/main.go`.
-   Look for `go:embed...`.
-3. Compute a new SHA-512 hash digest for your binary, typically by
+1. Compile your own signer and place it in the `cmd/tkey-ssh-agent`
+   directory.
+2. Change the path to the embedded signer in
+   `cmd/tkey-ssh-agent/signer.go`. Look for `go:embed...`.
+3. Change the `appName` directly under the `go:embed` to whatever your
+   signer is called so the agent reports this correctly with
+   `--version`.
+4. Compute a new SHA-512 hash digest for your binary, typically by
    something like `sha512sum cmd/tkey-ssh-agent/signer.bin-v0.0.7` and
    put the resulting output in the file `signer.bin.sha512` at the top
    level.
-4. `make` in the top level.
+5. `make` in the top level.
 
 If you want to use the `build.sh` script you change the
 `signer_version` variable and the URL used to clone the signer device

--- a/cmd/tkey-ssh-agent/main.go
+++ b/cmd/tkey-ssh-agent/main.go
@@ -99,7 +99,8 @@ will flash green when the stick must be touched to complete a signature.`, progn
 		exit(0)
 	}
 	if versionOnly {
-		fmt.Printf("%s %s\n", progname, version)
+		fmt.Printf("%s %s\n\n", progname, version)
+		fmt.Printf("Embedded device app:\n%s\nSHA512: %s\n", GetEmbeddedAppName(), GetEmbeddedAppDigest())
 		exit(0)
 	}
 

--- a/cmd/tkey-ssh-agent/signer.go
+++ b/cmd/tkey-ssh-agent/signer.go
@@ -6,7 +6,9 @@ package main
 import (
 	"crypto"
 	"crypto/ed25519"
+	"crypto/sha512"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +29,8 @@ import (
 //
 //go:embed signer.bin-v0.0.7
 var appBinary []byte
+
+const appName string = "tkey-device-signer 0.0.7"
 
 var notify = func(msg string) {
 	tkeyutil.Notify(progname, msg)
@@ -308,4 +312,16 @@ func handleSignals(action func(), sig ...os.Signal) {
 			action()
 		}
 	}()
+}
+
+// GetEmbeddedAppName returns the name of the embedded device app.
+func GetEmbeddedAppName() string {
+	return appName
+}
+
+// GetEmbeddedAppDigest returns a string of the SHA512 digest for the embedded
+// device app
+func GetEmbeddedAppDigest() string {
+	digest := sha512.Sum512(appBinary)
+	return hex.EncodeToString(digest[:])
 }


### PR DESCRIPTION
Considered two options for implementing this:

1. Simply add a string variable underneath go:embed, to manually input the name/version of the embedded signer.
2. Instead use embed.FS, which has a method of getting the name of embedded files.

Since we are only embedding one file, and not multiple files in a file system I thought option one is good enough, to keep it simple.  
The confidence in knowing it is the right app lies in the sha512 digest which is included as well, which is calculated by hashing the embedded binary.