### PR TITLE
Display SHA512 digest when signer app is loaded

### DIFF
--- a/cmd/tkey-ssh-agent/apps.go
+++ b/cmd/tkey-ssh-agent/apps.go
@@ -41,11 +41,11 @@ func ListApps() []EmbeddedApp {
 	list := []EmbeddedApp{
 		{
 			name:   "tkey-device-signer 1.0.2",
-			digest: embeddedAppDigest(appBinaryPreCastor),
+			digest: AppDigest(appBinaryPreCastor),
 		},
 		{
 			name:   "tkey-device-signer castor-alpha-1",
-			digest: embeddedAppDigest(appBinaryCastor),
+			digest: AppDigest(appBinaryCastor),
 		},
 	}
 
@@ -69,7 +69,7 @@ func GetApp(pid uint8) ([]byte, error) {
 	return nil, ErrNotFound
 }
 
-func embeddedAppDigest(bin []byte) string {
+func AppDigest(bin []byte) string {
 	digest := sha512.Sum512(bin)
 	return hex.EncodeToString(digest[:])
 }

--- a/cmd/tkey-ssh-agent/signer.go
+++ b/cmd/tkey-ssh-agent/signer.go
@@ -195,7 +195,7 @@ func (s *Signer) loadApp(devApp []byte, udi tkeyclient.UDI) error {
 		}
 	}
 
-	le.Printf("Loading signer app...\n")
+	le.Printf("Loading signer app...\nSHA512: %s\n", AppDigest(devApp))
 	if err := s.tk.LoadApp(devApp, secret); err != nil {
 		return fmt.Errorf("LoadApp: %w", err)
 	}


### PR DESCRIPTION
## Description

Displaying the hash of the loaded app let's the user double check the automagic app choice based on product id.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
