### PR TITLE
Handle TKey Unlocked like Bellatrix (main)

### DIFF
--- a/cmd/tkey-ssh-agent/apps.go
+++ b/cmd/tkey-ssh-agent/apps.go
@@ -52,23 +52,24 @@ func ListApps() []EmbeddedApp {
 	return list
 }
 
-// GetApp looks up what type of app is needed depending on the UDI
-// product ID pid. It returns the app binary and any error.
-func GetApp(pid uint8) ([]byte, error) {
+// GetApp returns an app compatible with the device. Compatibility is
+// determined by the UDI product ID pid. For backwards compatibility
+// the pre Castor app is returned if pid is unknown.
+func GetApp(pid uint8) []byte {
 	switch pid {
 	case tkeyclient.UDIPIDEngSample:
-		return appBinaryCastor, nil
+		return appBinaryCastor
 	case tkeyclient.UDIPIDAcrab:
-		return appBinaryPreCastor, nil
+		return appBinaryPreCastor
 	case tkeyclient.UDIPIDBellatrix:
-		return appBinaryPreCastor, nil
+		return appBinaryPreCastor
 	case tkeyclient.UDIPIDBellatrixUnlocked:
-		return appBinaryPreCastor, nil
+		return appBinaryPreCastor
 	case tkeyclient.UDIPIDCastor:
-		return appBinaryCastor, nil
+		return appBinaryCastor
 	}
 
-	return nil, ErrNotFound
+	return appBinaryPreCastor
 }
 
 func AppDigest(bin []byte) string {

--- a/cmd/tkey-ssh-agent/apps.go
+++ b/cmd/tkey-ssh-agent/apps.go
@@ -62,6 +62,8 @@ func GetApp(pid uint8) ([]byte, error) {
 		return appBinaryPreCastor, nil
 	case tkeyclient.UDIPIDBellatrix:
 		return appBinaryPreCastor, nil
+	case tkeyclient.UDIPIDBellatrixUnlocked:
+		return appBinaryPreCastor, nil
 	case tkeyclient.UDIPIDCastor:
 		return appBinaryCastor, nil
 	}

--- a/cmd/tkey-ssh-agent/main.go
+++ b/cmd/tkey-ssh-agent/main.go
@@ -73,7 +73,7 @@ func main() {
 	pflag.BoolVar(&ussConf.EnterManually, "uss", false,
 		"Enable typing of a phrase to be hashed as the User Supplied Secret. The USS is loaded onto the TKey along with the app itself. A different USS results in different SSH public/private keys, meaning a different identity.")
 	pflag.BoolVar(&ussConf.ForceFullUSS, "force-full-uss", false,
-		"Force use of 32 byte USS digest on Bellatrix and earlier. Default on Castor and later.")
+		"Force use of 32 byte USS digest on Bellatrix and earlier. Default on Castor and later. Only usable with --uss or --uss-file.")
 	pflag.StringVar(&ussConf.Path, "uss-file", "",
 		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
 	pflag.StringVar(&ussConf.PinentryPath, "pinentry", "",
@@ -159,6 +159,12 @@ will flash green when the stick must be touched to complete a signature.`, progn
 
 	if ussConf.EnterManually && ussConf.Path != "" {
 		le.Printf("Pass only one of --uss or --uss-file.\n\n")
+		pflag.Usage()
+		exit(2)
+	}
+
+	if ussConf.ForceFullUSS && ussConf.Path == "" != ussConf.EnterManually {
+		le.Printf("--force-full-uss unusable unless you also specify --uss or --uss-file.\n\n")
 		pflag.Usage()
 		exit(2)
 	}

--- a/cmd/tkey-ssh-agent/signer.go
+++ b/cmd/tkey-ssh-agent/signer.go
@@ -130,13 +130,7 @@ func (s *Signer) connect() bool {
 			return false
 		}
 
-		app, err := GetApp(udi.ProductID)
-		if err != nil {
-			notify("Unknown product ID. Failed to identify what device app to use.")
-			s.closeNow()
-
-			return false
-		}
+		app := GetApp(udi.ProductID)
 
 		if err := s.loadApp(app, *udi); err != nil {
 			le.Printf("Failed to load app: %v\n", err)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,6 +11,8 @@
   instead.
 - Only allow `--force-full-uss` when either `--uss` or `--uss-file` is
   also set.
+- Update tkeyclient to v1.3.1 to handle TKey Unlocked (product ID 8)
+  as a Bellatrix when it comes to USS digest handling.
 
 ## v1.1.0
 
@@ -25,6 +27,9 @@ v1.0.0-maintenance, but the same changes are here.
 
 - Add a new option flag: `--force-full-uss` to force full use of the
   32 byte USS digest.
+
+Full
+[changelog](https://github.com/tillitis/tkey-ssh-agent/compare/v1.0.0...v1.1.0).
 
 ## v1.0.0
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -9,6 +9,8 @@
   earlier versions.
 - macOS: remove pinentry dependency and use built-in osascript
   instead.
+- Only allow `--force-full-uss` when either `--uss` or `--uss-file` is
+  also set.
 
 ## v1.1.0
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/getlantern/systray v1.2.2
 	github.com/spf13/pflag v1.0.5
 	github.com/tawesoft/golib/v2 v2.16.0
-	github.com/tillitis/tkeyclient v1.3.0
+	github.com/tillitis/tkeyclient v1.3.1
 	github.com/tillitis/tkeysign v1.1.0
 	github.com/tillitis/tkeyutil v0.0.8
 	github.com/twpayne/go-pinentry-minimal v0.0.0-20220113210447-2a5dc4396c2a

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG0
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
 github.com/tawesoft/golib/v2 v2.16.0 h1:QJPqTFPVz++45fTVyP66o8IfCfz8MYgTrn6nypVLv2o=
 github.com/tawesoft/golib/v2 v2.16.0/go.mod h1:S+cpYdLd1NwKQmWnycfIJqJegOek/Zz+JY9FH7EJTWs=
-github.com/tillitis/tkeyclient v1.3.0 h1:fUlghD+xvtL+qoajgrsetCC7KPwSfpjDDgqxMOBA2VU=
-github.com/tillitis/tkeyclient v1.3.0/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
+github.com/tillitis/tkeyclient v1.3.1 h1:IouMAtwwXewhXLmcySBmXuyFuI4WoAw8NQj+gFWlLaw=
+github.com/tillitis/tkeyclient v1.3.1/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
 github.com/tillitis/tkeysign v1.1.0 h1:a6fGmEsufsMh5amGIm9H8qmixNsuvWs8J/z4OPj4OGE=
 github.com/tillitis/tkeysign v1.1.0/go.mod h1:tpQhQBc2Vbr7WBTHBp0MPIzcOLasA+c23dmKxSgEvVQ=
 github.com/tillitis/tkeyutil v0.0.8 h1:CbDT6HDuma5/hNPZrZFGrZ1U/zAWH74bIbkqdHIHfKU=

--- a/system/tkey-ssh-agent.1
+++ b/system/tkey-ssh-agent.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "tkey-ssh-agent" "1" "2026-03-06"
+.TH "tkey-ssh-agent" "1" "2026-03-23"
 .PP
 .SH NAME
 .PP
@@ -57,6 +57,8 @@ Bind the agent to the UNIX-domain socket at path.\&
 .RS 4
 Force sending a 32 byte USS digest.\& For backwards compatibility
 the default is sending 31 bytes of the computed digest and a zero.\&
+.PP
+Only usable with \fB--uss\fR or \fB--uss-file\fR.\&
 .PP
 .RE
 \fB--help\fR

--- a/system/tkey-ssh-agent.scd
+++ b/system/tkey-ssh-agent.scd
@@ -46,6 +46,8 @@ The options are as follows:
 	Force sending a 32 byte USS digest. For backwards compatibility
 	the default is sending 31 bytes of the computed digest and a zero.
 
+	Only usable with *--uss* or *--uss-file*.
+
 *--help*
 
 	Output help text and exit.


### PR DESCRIPTION
## Description

- Update tkeyclient to hanle Tkey Unlocked like Bellatrix.

- Only allow --force-full-uss with --uss or --uss-file


## Type of change

- [x] Bugfix (non breaking change which resolve an issue)
- [x] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
