### PR TITLE
Add --remind-delay to customize delay before notifying user to touch

### DIFF
--- a/cmd/tkey-ssh-agent/main.go
+++ b/cmd/tkey-ssh-agent/main.go
@@ -51,6 +51,7 @@ func main() {
 	var ussConf UssConfig
 	var agentPath string
 	var showPubkeyOnly, listPortsOnly, versionOnly, helpOnly bool
+	var remindDelay int
 	pflag.CommandLine.SetOutput(os.Stderr)
 	pflag.CommandLine.SortFlags = false
 	pflag.CommandLine.SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
@@ -78,6 +79,8 @@ func main() {
 		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
 	pflag.StringVar(&ussConf.PinentryPath, "pinentry", "",
 		"Pinentry `PROGRAM` for use by --uss. The default is found by looking in your gpg-agent.conf for pinentry-program, or 'pinentry' if not found there. On Windows, an attempt is made to find Gpg4win's pinentry program to use as default. On macOS, a native prompt is used by default.")
+	pflag.IntVar(&remindDelay, "remind-delay", 4,
+		"Delay in `SECONDS` before sending a notification reminding the user to touch the TKey to confirm SSH login.")
 	pflag.BoolVar(&versionOnly, "version", false, "Output version information.")
 	pflag.BoolVar(&helpOnly, "help", false, "Output this help.")
 	pflag.Usage = func() {
@@ -169,13 +172,19 @@ will flash green when the stick must be touched to complete a signature.`, progn
 		exit(2)
 	}
 
+	if remindDelay < 0 {
+		le.Printf("--remind-delay cannot be negative.\n\n")
+		pflag.Usage()
+		exit(2)
+	}
+
 	prevExitFunc := exit
 	exit = func(code int) {
 		_ = os.Remove(agentPath)
 		prevExitFunc(code)
 	}
 
-	signer := NewSigner(port, ussConf, exit)
+	signer := NewSigner(port, ussConf, remindDelay, exit)
 
 	if showPubkeyOnly {
 		if !signer.connect() {

--- a/cmd/tkey-ssh-agent/signer.go
+++ b/cmd/tkey-ssh-agent/signer.go
@@ -42,9 +42,10 @@ type Signer struct {
 	mu              sync.Mutex
 	connected       bool
 	disconnectTimer *time.Timer
+	remindDelay     int
 }
 
-func NewSigner(port Port, uss UssConfig, exitFunc func(int)) *Signer {
+func NewSigner(port Port, uss UssConfig, remindDelay int, exitFunc func(int)) *Signer {
 	var signer Signer
 
 	tkeyclient.SilenceLogging()
@@ -53,10 +54,11 @@ func NewSigner(port Port, uss UssConfig, exitFunc func(int)) *Signer {
 
 	tkSigner := tkeysign.New(tk)
 	signer = Signer{
-		tk:       tk,
-		tkSigner: &tkSigner,
-		port:     port,
-		uss:      uss,
+		tk:          tk,
+		tkSigner:    &tkSigner,
+		port:        port,
+		uss:         uss,
+		remindDelay: remindDelay,
 	}
 
 	// Do nothing on HUP, in case old udev rule is still in effect

--- a/cmd/tkey-ssh-agent/sshagent.go
+++ b/cmd/tkey-ssh-agent/sshagent.go
@@ -102,10 +102,16 @@ func (s *SSHAgent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) 
 	}
 
 	if signerAppNoTouch == "" {
-		timer := time.AfterFunc(4*time.Second, func() {
+		delaySeconds := s.signer.remindDelay
+		showReminder := func() {
 			notify("Touch your TKey to confirm SSH login.")
-		})
-		defer timer.Stop()
+		}
+		if delaySeconds == 0 {
+			showReminder()
+		} else {
+			timer := time.AfterFunc(time.Duration(delaySeconds)*time.Second, showReminder)
+			defer timer.Stop()
+		}
 
 		le.Printf("Sign: user will have to touch the TKey\n")
 	} else {

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -13,6 +13,8 @@
   also set.
 - Update tkeyclient to v1.3.1 to handle TKey Unlocked (product ID 8)
   as a Bellatrix when it comes to USS digest handling.
+- Add flag `--remind-delay` to customize delay before sending
+  notificaton to remind about touch.
 
 ## v1.1.0
 

--- a/system/tkey-ssh-agent.1
+++ b/system/tkey-ssh-agent.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "tkey-ssh-agent" "1" "2026-03-23"
+.TH "tkey-ssh-agent" "1" "2026-04-16"
 .PP
 .SH NAME
 .PP
@@ -86,6 +86,14 @@ found, the \fBpinentry(1)\fR command is used.\&
 .RS 4
 Set serial port device path.\& If this is not set, auto-detection will
 be attempted.\&
+.PP
+.RE
+\fB--remind-delay seconds\fR
+.PP
+.RS 4
+Delay in seconds before sending a notification reminding the
+user to touch the TKey to confirm SSH login.\& Default is 4
+seconds.\&
 .PP
 .RE
 \fB--speed bit_speed\fR

--- a/system/tkey-ssh-agent.scd
+++ b/system/tkey-ssh-agent.scd
@@ -67,6 +67,12 @@ The options are as follows:
 	Set serial port device path. If this is not set, auto-detection will
 	be attempted.
 
+*--remind-delay seconds*
+
+	Delay in seconds before sending a notification reminding the
+	user to touch the TKey to confirm SSH login. Default is 4
+	seconds.
+
 *--speed bit_speed*
 
 	Set serial port speed in bits per second. Default is 62500 b/s.


### PR DESCRIPTION
## Description

Add flag --remind-delay to customize the delay in seconds after which a notification is sent to remind user to touch the TKey. Default is the classic 4 seconds.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
