### PR TITLE
Add --serial for connecting only to one specific TKey

### DIFF
--- a/cmd/tkey-ssh-agent/main.go
+++ b/cmd/tkey-ssh-agent/main.go
@@ -27,8 +27,9 @@ var version string
 const windowsPipePrefix = `\\.\pipe\`
 
 type Port struct {
-	Path  string
-	Speed int
+	Path   string
+	Serial string
+	Speed  int
 }
 
 type UssConfig struct {
@@ -69,6 +70,8 @@ func main() {
 		"List possible serial ports to use with --port.")
 	pflag.StringVar(&port.Path, "port", "",
 		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
+	pflag.StringVar(&port.Serial, "serial", "",
+		"During port auto-detection, consider only a TKey with a specific `SERIALNUMBER` (as shown by --list-ports). Cannot be used together with --port.")
 	pflag.IntVar(&port.Speed, "speed", 0,
 		"Set serial port speed in `BPS` (bits per second).")
 	pflag.BoolVar(&ussConf.EnterManually, "uss", false,
@@ -156,6 +159,12 @@ will flash green when the stick must be touched to complete a signature.`, progn
 
 	if !showPubkeyOnly && agentPath == "" {
 		le.Printf("Please pass at least -a or -p.\n\n")
+		pflag.Usage()
+		exit(2)
+	}
+
+	if port.Path != "" && port.Serial != "" {
+		le.Printf("Pass only one of --port or --serial.\n\n")
 		pflag.Usage()
 		exit(2)
 	}

--- a/cmd/tkey-ssh-agent/signer.go
+++ b/cmd/tkey-ssh-agent/signer.go
@@ -89,13 +89,15 @@ func (s *Signer) connect() bool {
 	devPath := s.port.Path
 	if devPath == "" {
 		var err error
-		devPath, err = tkeyclient.DetectSerialPort(false)
+		devPath, err = detectSerialPort(s.port.Serial)
 		if err != nil {
 			switch {
 			case errors.Is(err, tkeyclient.ErrNoDevice):
 				notify("Could not find any TKey plugged in.")
 			case errors.Is(err, tkeyclient.ErrManyDevices):
 				notify("Cannot work with more than 1 TKey plugged in.")
+			case errors.Is(err, errDeviceSerialNotFound):
+				notify(fmt.Sprintf("Could not find TKey with serialnumber %s.", s.port.Serial))
 			default:
 				notify(fmt.Sprintf("TKey detection failed: %s\n", err))
 			}
@@ -157,6 +159,40 @@ func (s *Signer) connect() bool {
 
 	s.connected = true
 	return true
+}
+
+const errDeviceSerialNotFound = constError("TKey with specific serial not connected")
+
+// DetectSerialPort tries to detect an inserted TKey and returns the
+// device path if successful. If passed an empty serial string,
+// detecting multiple TKeys always returns an error. If serial is
+// non-empty, the serial number of a detected TKey must match this. In
+// this case, multiple TKeys are handled by returning the first TKey
+// with a matching serial number. This function is based on
+// tkeyclient.DetectSerialPort.
+func detectSerialPort(serial string) (string, error) {
+	ports, err := tkeyclient.GetSerialPorts()
+	if err != nil {
+		return "", fmt.Errorf("failed GetSerialPorts: %w", err)
+	}
+	if len(ports) == 0 {
+		return "", tkeyclient.ErrNoDevice
+	}
+
+	if serial != "" {
+		for i := range ports {
+			if ports[i].SerialNumber == serial {
+				return ports[i].DevPath, nil
+			}
+		}
+		return "", errDeviceSerialNotFound
+	}
+
+	if len(ports) > 1 {
+		return "", tkeyclient.ErrManyDevices
+	}
+
+	return ports[0].DevPath, nil
 }
 
 func (s *Signer) isFirmwareMode() bool {

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,6 +15,8 @@
   as a Bellatrix when it comes to USS digest handling.
 - Add flag `--remind-delay` to customize delay before sending
   notificaton to remind about touch.
+- Add flag `--serial` for only connecting to a TKey with specific
+  serial number.
 
 ## v1.1.0
 

--- a/system/tkey-ssh-agent.1
+++ b/system/tkey-ssh-agent.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "tkey-ssh-agent" "1" "2026-04-16"
+.TH "tkey-ssh-agent" "1" "2026-08-03"
 .PP
 .SH NAME
 .PP
@@ -21,7 +21,7 @@ tkey-ssh-agent – An SSH agent backed by Tillitis TKey
 .PP
 \fBtkey-ssh-agent\fR -L | --list-ports
 .PP
-\fBtkey-ssh-agent\fR [-a | --agent-path path] [--force-full-uss] [-p | --show-pubkey] [--pinentry command] [--port path] [--speed bit_speed] [--uss] [--uss-file path]
+\fBtkey-ssh-agent\fR [-a | --agent-path path] [--force-full-uss] [-p | --show-pubkey] [--pinentry command] [--port path] [--serial serialnumber] [--speed bit_speed] [--uss] [--uss-file path]
 .PP
 .SH DESCRIPTION
 .PP
@@ -94,6 +94,14 @@ be attempted.\&
 Delay in seconds before sending a notification reminding the
 user to touch the TKey to confirm SSH login.\& Default is 4
 seconds.\&
+.PP
+.RE
+\fB--serial serialnumber\fR
+.PP
+.RS 4
+During port auto-detection, consider only a TKey with a specific
+serialnumber (as shown by --list-ports).\& Cannot be used together
+with --port.\&
 .PP
 .RE
 \fB--speed bit_speed\fR
@@ -211,6 +219,16 @@ interactively ask for the User Supplied Secret:
 .nf
 .RS 4
 $ tkey-ssh-agent -a \&./agent\&.sock --uss
+.fi
+.RE
+.PP
+Running with automatic port detection, connecting only to a TKey with
+aspecific serial number.\& This makes it possible to keep multiple TKeys
+plugged in; this agent will only connect to a specific one.\&
+.PP
+.nf
+.RS 4
+$ tkey-ssh-agent -a \&./agent\&.sock --uss --serial 8b8d3600_084a_3cff_ff0f_0d3fac30f45c
 .fi
 .RE
 .PP

--- a/system/tkey-ssh-agent.scd
+++ b/system/tkey-ssh-agent.scd
@@ -14,7 +14,7 @@ tkey-ssh-agent – An SSH agent backed by Tillitis TKey
 
 *tkey-ssh-agent* -L | --list-ports
 
-*tkey-ssh-agent* [-a | --agent-path path] [--force-full-uss] [-p | --show-pubkey] [--pinentry command] [--port path] [--speed bit_speed] [--uss] [--uss-file path]
+*tkey-ssh-agent* [-a | --agent-path path] [--force-full-uss] [-p | --show-pubkey] [--pinentry command] [--port path] [--serial serialnumber] [--speed bit_speed] [--uss] [--uss-file path]
 
 # DESCRIPTION
 
@@ -72,6 +72,12 @@ The options are as follows:
 	Delay in seconds before sending a notification reminding the
 	user to touch the TKey to confirm SSH login. Default is 4
 	seconds.
+
+*--serial serialnumber*
+
+	During port auto-detection, consider only a TKey with a specific
+	serialnumber (as shown by --list-ports). Cannot be used together
+	with --port.
 
 *--speed bit_speed*
 
@@ -169,6 +175,14 @@ interactively ask for the User Supplied Secret:
 
 ```
 $ tkey-ssh-agent -a ./agent.sock --uss
+```
+
+Running with automatic port detection, connecting only to a TKey with
+aspecific serial number. This makes it possible to keep multiple TKeys
+plugged in; this agent will only connect to a specific one.
+
+```
+$ tkey-ssh-agent -a ./agent.sock --uss --serial 8b8d3600_084a_3cff_ff0f_0d3fac30f45c
 ```
 
 Running manually against qemu (look when qemu is starting what device it


### PR DESCRIPTION

## Description

When --serial is used, the agent will support multiple TKeys being plugged in, and will only use one which has a matching serial number (if any).

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
