### PR TITLE
Make firmware probe only react on specific error

### DIFF
--- a/cmd/tkey-ssh-agent/signer.go
+++ b/cmd/tkey-ssh-agent/signer.go
@@ -161,7 +161,7 @@ func (s *Signer) connect() bool {
 
 func (s *Signer) isFirmwareMode() bool {
 	nameVer, err := s.tk.GetNameVersion()
-	if err != nil {
+	if errors.Is(err, tkeyclient.ErrResponseStatusNotOK) {
 		return false
 	}
 	// not caring about nameVer.Version


### PR DESCRIPTION
## Description

Instead of thinking a TKey is running a device app on any error from the firmware probe, just report a device app if we get the specific ErrResponseStatusNotOK error.

Fixes #157 

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] ~I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.~
- [ ] ~I have updated the documentation where relevant (readme, dev.tillitis.se etc.)~
- [ ] ~QEMU is updated to reflect changes~
